### PR TITLE
Revive model index

### DIFF
--- a/Models/model-index.json
+++ b/Models/model-index.json
@@ -1,15 +1,5 @@
 [
   {
-    "name": "2CylinderEngine",
-    "screenshot": "screenshot/screenshot.png",
-    "variants": {
-      "glTF": "2CylinderEngine.gltf",
-      "glTF-Binary": "2CylinderEngine.glb",
-      "glTF-Draco": "2CylinderEngine.gltf",
-      "glTF-Embedded": "2CylinderEngine.gltf"
-    }
-  },
-  {
     "name": "ABeautifulGame",
     "screenshot": "screenshot/screenshot.jpg",
     "variants": {
@@ -55,6 +45,31 @@
     "variants": {
       "glTF": "AnimatedTriangle.gltf",
       "glTF-Embedded": "AnimatedTriangle.gltf"
+    }
+  },
+  {
+    "name": "AnisotropyBarnLamp",
+    "screenshot": "screenshot/screenshot.jpg",
+    "variants": {
+      "glTF": "AnisotropyBarnLamp.gltf",
+      "glTF-Binary": "AnisotropyBarnLamp.glb",
+      "glTF-KTX2-Basisu": "AnisotropyBarnLamp.gltf"
+    }
+  },
+  {
+    "name": "AnisotropyRotationTest",
+    "screenshot": "screenshot/screenshot.png",
+    "variants": {
+      "glTF": "AnisotropyRotationTest.gltf",
+      "glTF-Binary": "AnisotropyRotationTest.glb"
+    }
+  },
+  {
+    "name": "AnisotropyStrengthTest",
+    "screenshot": "screenshot/screenshot.png",
+    "variants": {
+      "glTF": "AnisotropyStrengthTest.gltf",
+      "glTF-Binary": "AnisotropyStrengthTest.glb"
     }
   },
   {
@@ -181,16 +196,6 @@
     }
   },
   {
-    "name": "Buggy",
-    "screenshot": "screenshot/screenshot.png",
-    "variants": {
-      "glTF": "Buggy.gltf",
-      "glTF-Binary": "Buggy.glb",
-      "glTF-Draco": "Buggy.gltf",
-      "glTF-Embedded": "Buggy.gltf"
-    }
-  },
-  {
     "name": "Cameras",
     "screenshot": "screenshot/screenshot.png",
     "variants": {
@@ -219,11 +224,27 @@
     }
   },
   {
+    "name": "ClearCoatCarPaint",
+    "screenshot": "screenshot/screenshot.jpg",
+    "variants": {
+      "glTF": "ClearCoatCarPaint.gltf",
+      "glTF-Binary": "ClearCoatCarPaint.glb"
+    }
+  },
+  {
     "name": "ClearCoatTest",
     "screenshot": "screenshot/screenshot.jpg",
     "variants": {
       "glTF": "ClearCoatTest.gltf",
       "glTF-Binary": "ClearCoatTest.glb"
+    }
+  },
+  {
+    "name": "ClearcoatWicker",
+    "screenshot": "screenshot/screenshot.jpg",
+    "variants": {
+      "glTF": "ClearcoatWicker.gltf",
+      "glTF-Binary": "ClearcoatWicker.glb"
     }
   },
   {
@@ -302,16 +323,6 @@
     }
   },
   {
-    "name": "GearboxAssy",
-    "screenshot": "screenshot/screenshot.png",
-    "variants": {
-      "glTF": "GearboxAssy.gltf",
-      "glTF-Binary": "GearboxAssy.glb",
-      "glTF-Draco": "GearboxAssy.gltf",
-      "glTF-Embedded": "GearboxAssy.gltf"
-    }
-  },
-  {
     "name": "GlamVelvetSofa",
     "screenshot": "screenshot/screenshot.jpg",
     "variants": {
@@ -320,11 +331,43 @@
     }
   },
   {
+    "name": "GlassBrokenWindow",
+    "screenshot": "screenshot/screenshot.jpg",
+    "variants": {
+      "glTF": "GlassBrokenWindow.gltf",
+      "glTF-Binary": "GlassBrokenWindow.glb"
+    }
+  },
+  {
+    "name": "GlassHurricaneCandleHolder",
+    "screenshot": "screenshot/screenshot.jpg",
+    "variants": {
+      "glTF": "GlassHurricaneCandleHolder.gltf",
+      "glTF-Binary": "GlassHurricaneCandleHolder.glb"
+    }
+  },
+  {
+    "name": "GlassVaseFlowers",
+    "screenshot": "screenshot/screenshot.jpg",
+    "variants": {
+      "glTF": "GlassVaseFlowers.gltf",
+      "glTF-Binary": "GlassVaseFlowers.glb"
+    }
+  },
+  {
     "name": "InterpolationTest",
     "screenshot": "screenshot/screenshot.gif",
     "variants": {
       "glTF": "InterpolationTest.gltf",
       "glTF-Binary": "InterpolationTest.glb"
+    }
+  },
+  {
+    "name": "IridescenceAbalone",
+    "screenshot": "screenshot/screenshot.jpg",
+    "variants": {
+      "glTF": "IridescenceAbalone.gltf",
+      "glTF-Binary": "IridescenceAbalone.glb"
     }
   },
   {
@@ -392,6 +435,14 @@
     }
   },
   {
+    "name": "MeshPrimitiveModes",
+    "screenshot": "screenshot/screenshot.png",
+    "variants": {
+      "glTF": "MeshPrimitiveModes.gltf",
+      "glTF-Embedded": "MeshPrimitiveModes.gltf"
+    }
+  },
+  {
     "name": "MetalRoughSpheres",
     "screenshot": "screenshot/screenshot.png",
     "variants": {
@@ -443,6 +494,22 @@
     }
   },
   {
+    "name": "MultipleScenes",
+    "screenshot": "screenshot/screenshot.png",
+    "variants": {
+      "glTF": "MultipleScenes.gltf",
+      "glTF-Embedded": "MultipleScenes.gltf"
+    }
+  },
+  {
+    "name": "NegativeScaleTest",
+    "screenshot": "screenshot/screenshot.jpg",
+    "variants": {
+      "glTF": "NegativeScaleTest.gltf",
+      "glTF-Binary": "NegativeScaleTest.glb"
+    }
+  },
+  {
     "name": "NormalTangentMirrorTest",
     "screenshot": "screenshot/screenshot.png",
     "variants": {
@@ -467,16 +534,6 @@
       "glTF": "OrientationTest.gltf",
       "glTF-Binary": "OrientationTest.glb",
       "glTF-Embedded": "OrientationTest.gltf"
-    }
-  },
-  {
-    "name": "ReciprocatingSaw",
-    "screenshot": "screenshot/screenshot.png",
-    "variants": {
-      "glTF": "ReciprocatingSaw.gltf",
-      "glTF-Binary": "ReciprocatingSaw.glb",
-      "glTF-Draco": "ReciprocatingSaw.gltf",
-      "glTF-Embedded": "ReciprocatingSaw.gltf"
     }
   },
   {
@@ -527,6 +584,14 @@
     "screenshot": "screenshot/screenshot.jpg",
     "variants": {
       "glTF": "SheenCloth.gltf"
+    }
+  },
+  {
+    "name": "SimpleInstancing",
+    "screenshot": "screenshot/screenshot.png",
+    "variants": {
+      "glTF": "SimpleInstancing.gltf",
+      "glTF-Binary": "SimpleInstancing.glb"
     }
   },
   {

--- a/util/generate-index.py
+++ b/util/generate-index.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+import json
+import os
+
+
+def generate_index(root):
+    os.chdir(root)
+    index = []
+    for model in sorted(os.listdir(".")):
+        if not os.path.isdir(model):
+            continue
+        os.chdir(model)
+        model_contents = os.listdir(".")
+        gltf_variant_dirs = [d for d in model_contents if d.startswith("glTF")]
+        variants = {}
+        for variant_dir in gltf_variant_dirs:
+            model_file_list = [f for f in os.listdir(variant_dir)
+                          if f.endswith(".glb") or f.endswith(".gltf")]
+            if (len(model_file_list) > 0):
+                variants[variant_dir] = model_file_list[0]
+        if not variants:
+            print ("WARNING: no model files found for {}".format(model))
+        else:
+            model_info = {
+                "name": model,
+                "variants": variants,
+                "screenshot": None
+            }
+            if "screenshot" not in model_contents:
+                print ("WARNING: no screenshot found for {}".format(model))
+            else:
+                model_info["screenshot"] = "screenshot/" + [s for s in os.listdir("screenshot") if s.startswith("screenshot.")][0]
+            index.append(model_info)
+        os.chdir("..")
+
+    with open("model-index.json", "w") as f:
+        json.dump(index, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+    os.chdir("..")
+
+generate_index("../Models")


### PR DESCRIPTION
The `glTF-Sample-Models` repo contained a [`model-index.json`](https://github.com/KhronosGroup/glTF-Sample-Models/blob/4ca06672ce15d6a27bfb5cf14459bc52fd9044d1/2.0/model-index.json) file that contained information about all available models and variants. This index file was generated with the [`generate-index.py`](https://github.com/KhronosGroup/glTF-Sample-Models/blob/4ca06672ce15d6a27bfb5cf14459bc52fd9044d1/generate-index.py) script.

I have seen the [`allModels.json`](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/5ce2019eb14c553d5a2adbff144250c357a29f23/allModels.json) that also lists all models, but it does not list the variants, file names, and screenshot names.

I think that the `model-index.json` should still exist somewhere. Otherwise, all the tools that rely on this file would be broken. 

Some options:

- Add the missing information about the variants in the `allModels.json`. 
  - This would still be a brekaing change for toolchains that already rely on the `model-index.json`
- Add the `tags` as they are currently contained in the `allModels.json` to the `model-index.json`. This would be backward-compatible: Tools that already read the `model-index.json`  would just ignore the `tags`. 

Further options (depending on the choice above): 

- Extend the current PHP code to generate the information from the `model-index.json`, including the `tags`
- Use the original `generate-index.py` to generate the `model-index.json`, and extend _that_ to include the `tags` there

We could have both, the `allModels.json` and the `model-index.json`, but having only one source of truth would certainly be easier to maintain. (And in any case: This source of truth could be updated automatically with GitHub actions after PullRequests)

