### PR TITLE
Updated submission info

### DIFF
--- a/SubmittingModels.md
+++ b/SubmittingModels.md
@@ -1,6 +1,3 @@
-<p align="center">
-<img src="2.0/glTF_RGB_June16.svg" height="100">
-</p>
 
 # Submitting New Models
 
@@ -20,39 +17,40 @@ There are a few things that are required for any contribution that are listed he
 To contribute a model, open a pull request with a new subdirectory containing the above listed items. many of the items go into subdirectories. The details are as follows:
 
 1. glTF Model
-    1. The model in as many glTF variations as reasonable (using the same directory structure as the others ([example](Models/Box))). Tools for converting to glTF are [here](https://github.com/KhronosGroup/glTF#converters).
-    1. Each format should be in its own separate directory
-    1. The model must use glTF Core V2.0 format and structure
-    1. The model should only use ratified glTF extensions
-1. A screenshot of the model, stored in a subdirectory called `/screenshot`
+    1. The model in as many glTF variations as reasonable. 
+       2. Each variant must be in its own subdirectory ([example](Models/Box))
+       3. Tools for converting to glTF can be found with the [glTF-Project-Explorer](https://github.khronos.org/glTF-Project-Explorer/)
+    3. The model must use glTF Core V2.0 format and structure, meaning that it must pass validation with the [glTF-Validator](https://github.com/KhronosGroup/glTF-Validator) without errors
+    4. The model should only use ratified glTF extensions
+2. A screenshot of the model, stored in a subdirectory called `/screenshot`
     1. The screenshot file should be called `screenshot` with an extension appropriate to the file format.
-    1. The screenshot must include all of the model, preferably in the orientation when first displayed
+    2. The screenshot must include all of the model, preferably in the orientation when first displayed
         1. The largest dimension should be no more than 150 pixels
-        1. The image file format should be the one that is smallest for the content. The preference is for JPEG formatted files, but PNG, WebP are also acceptable. If the image is animated, a GIF formatted file may be used to capture the animation.
-1. The model description
+        2. The image file format should be the one that is smallest for the content. The preference is for JPEG formatted files, but PNG, WebP are also acceptable. If the image is animated, a GIF formatted file may be used to capture the animation.
+3. The model description
     1. This is in Markdown format (`.md`).
-    1. The filename must be README.body.md
-    1. The description file must not include the following items. They are automatically provided by the build software.
+    2. The filename must be README.body.md
+    3. The description file must not include the following items. They are automatically provided by the build software.
         1. Top-level (`#`) tag for the model name
-        1. Second-level (`##`) tag for the model tags
-        1. Second-level (`##`) tag for the model summary
-        1. Second-level (`##`) tag for the model legal, copyright, and license information
-    1. The description file must include the following items.
+        2. Second-level (`##`) tag for the model tags
+        3. Second-level (`##`) tag for the model summary
+        4. Second-level (`##`) tag for the model legal, copyright, and license information
+    4. The description file must include the following items.
         1. Second-level (`##`) tag for the model screenshot
-        1. Second-level (`##`) tag for the model description
-    1. The description should also have a screen shot. 
+        2. Second-level (`##`) tag for the model description
+    5. The description should also have a screen shot. 
         1. This screen shot should have the horizontal dimension between 1000 to 2000 pixels
-        1. The vertical dimension should be between 500 to 1000 pixels
-        1. The model needs to retain the proper perspective.
-        1. The file name may be anything but `screenshot`. `screenshot_large` is frequently used.
-        1. The file must reside in the `screenshot` directory.
+        2. The vertical dimension should be between 500 to 1000 pixels
+        3. The model needs to retain the proper perspective.
+        4. The file name may be anything but `screenshot`. `screenshot_large` is frequently used.
+        5. The file must reside in the `screenshot` directory.
 
-1. Metadata
+4. Metadata
     1. All metadata is stored in `metadata.json`. It contains various information about the model.
-    1. There is an [experimental HTML application](../util/CreateJson.html) to assist in the creation of the Metadata file
-    1. The Metadata file may be generated manually.
-    1. The Metadata file will be automatically upgrade if needed during system upgrades.
-    1. See **Example Metadata File** (below) for details
+    2. There is an [experimental HTML application](./util/CreateJson.html) to assist in the creation of the Metadata file
+    3. The Metadata file may be generated manually.
+    4. The Metadata file will be automatically upgrade if needed during system upgrades.
+    5. See **Example Metadata File** (below) for details
 
 ## Asset Licenses
 
@@ -112,9 +110,9 @@ The _legal_ structure contains information about each owner of the model. It com
 * _artist_: The name of the artist(s) who performed the _what_.
 * _owner_: The owner of the model for this operation. This is may be the _artist_ or the organization responsible for the _artist_. If the work is in the Public Domain, then the _owner_ may be **Public**.
 * _year_: The year the work was performed.
-* _license_: The licensed assigned by the owner. Standard license shorthand should be used. The known shorthand is
+* _license_: The license assigned by the owner. Standard license shorthand should be used. The known shorthand is
 
-  * CCO
+  * CCO-1.0
   * PD
   * CC-BY / CC-BY International 4.0
   * CC-BY-ND


### PR DESCRIPTION
The [`SubmittingModels.md`](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/5bad5aaa0bbb5d0f9cdc934e626f27d0df1e79b8/SubmittingModels.md) may have to be reviewed. 

Things that are fixed in the current state of this PR:

- Removed an inlined image that does not exist
- Fix broken link to `#converters`. Minor rewording of the variants. Added requirement that models pass validation (!)
- Started updating the description of the `metadata.json`

Here, I stumbled: The description of the JSON there is a bit incomplete, and I'm not sure how to complete this: 

-  What is `version: 2`? (I wondered whether this referred to glTF itself...). 
- Which are valid `tags`? (Yeah, 🐘 -> 🏠 ) 
- Suggestions:
  - `name`: The name of the subdirectory that the model is contained in
  - `path`: The path of the model subdirectory, relative to the repository root
  - `screenshot`: The path to the screenshot, _relative_ to the model subdirectory
  - `summary`: A short description of what the model is or demonstrates
  - `createReadme`: Should always be `true`

The `legal` part also does not seem to list everything that can be found in the actual JSON files. One example is
```
            "license": "CC-BY 4.0",
            "licenseUrl": "https://creativecommons.org/licenses/by/4.0/legalcode",
            "artist": "Cesium",
            "year": "2017",
            "owner": "Cesium",
            "what": "Everything",
            "text": "CC BY 4.0 International",
            "spdx": "CC-BY-4.0",
            "icon": "https://licensebuttons.net/l/by/3.0/88x31.png"
```
That looks like a lot of redundant redundancy, which is pretty redundant. 
- What is the difference between `license` and `spdx`? If `license` is only intended for non-spdx licenses, then I wonder whether this could be merged into `license`, with the values either being one of the spdx-identifiers, or `"Custom"`.
- Is `text` really only for the link text, and does it make a difference of whether the link text is [CC-BY 4.0](http://example.com) or [CC-BY 4.0 International](http://example.com) ?
- That `icon` link... hm. Is this _necessary_ and _useful_? Even if the answer is 'yes': Is "hotlinking" to a random PNG file the right thing to do here...?
- There should be details about the artist/owner. For example, at least I guess: "The names of artists, separated by comma,..."

And... most importantly: What exactly do _submitters_ have to do here? Which of these fields are (or can be) auto-filled: I've seen that link to the `CreateJson.html` (which of course does not work on GitHub...), but is this supposed to fill out most of this information based on less input? Users shouldn't have to figure out the `licenseUrl` on their own, and it would be hard to make sure that the information in the given form is _consistent_ ...

