### PR TITLE
removed core tag in metadata

### DIFF
--- a/Models/AttenuationTest/metadata.json
+++ b/Models/AttenuationTest/metadata.json
@@ -14,7 +14,6 @@
         }
     ],
     "tags": [
-        "core",
         "testing",
         "extension"
     ],


### PR DESCRIPTION
addresses #16.
There may have been an automated process to determine metadata tags from source materials but the glTF-Sample-Model repo does not appear to have such a source.