### PR TITLE
 Use KHR_materials_transmission in FlightHelmet

### DIFF
--- a/Models/FlightHelmet/glTF/FlightHelmet.gltf
+++ b/Models/FlightHelmet/glTF/FlightHelmet.gltf
@@ -3,6 +3,9 @@
         "version": "2.0",
         "generator": "babylon.js glTF exporter for Maya 2018 v20200228.3 (with minor hand modifications)"
     },
+    "extensionsUsed": [
+        "KHR_materials_transmission"
+    ],
     "scene": 0,
     "scenes": [
         {
@@ -554,6 +557,11 @@
             "name": "LeatherPartsMat"
         },
         {
+            "extensions": {
+                "KHR_materials_transmission": {
+                    "transmissionFactor": 1
+                }
+            },
             "pbrMetallicRoughness": {
                 "baseColorTexture": {
                     "index": 14
@@ -568,7 +576,6 @@
             "occlusionTexture": {
                 "index": 13
             },
-            "alphaMode": "BLEND",
             "name": "LensesMat"
         }
     ],


### PR DESCRIPTION
Every engine seem to be handling `alphaMode: BLEND` differently (used in the glasses):

![Screenshot 2023-10-17 at 4 28 19 PM](https://github.com/KhronosGroup/glTF-Sample-Assets/assets/97088/17c669c3-2436-494b-bf42-79692c96fded)

`KHR_materials_transmission` seems to have better alignment so I propose updating this model with the extension.

/cc @elalish