### PR TITLE
Fix relative links in README of Models subdirectory

### DIFF
--- a/Models/README.md
+++ b/Models/README.md
@@ -2,10 +2,10 @@
 
 This interface to the model repository is obsolete. You need to use one of the new interfaces from the list below:
 
-* [Showcase](../Models-showcase.md) for models that are showcased in Khronos publicity. These are usually complex models with high visual quality.
-* [Complete](../Models.md) for a complete list of all models.
-* [Testing](../Models-testing.md) for models intended to be used for testing of viewers, converts, and other software systems.
-* [Core Only](../Models-core.md) for models that only use glTF Core V2.0 features and capabilities (no extensions).
-* [Video Tutorials](../Models-video.md) for models used in any glTF Tutorial video.
-* [Written Tutorials](../Models-written.md) for models used in a written glTF Tutorial.
-* [Issues](../Models-issues.md) for models with one or more issues that need to be resolved.
+* [Showcase](./Models-showcase.md) for models that are showcased in Khronos publicity. These are usually complex models with high visual quality.
+* [Complete](./Models.md) for a complete list of all models.
+* [Testing](./Models-testing.md) for models intended to be used for testing of viewers, converts, and other software systems.
+* [Core Only](./Models-core.md) for models that only use glTF Core V2.0 features and capabilities (no extensions).
+* [Video Tutorials](./Models-video.md) for models used in any glTF Tutorial video.
+* [Written Tutorials](./Models-written.md) for models used in a written glTF Tutorial.
+* [Issues](./Models-issues.md) for models with one or more issues that need to be resolved.


### PR DESCRIPTION
It seems like these files are in the same directory as this README. Although is explicit about being obsolete, it might be more helpful as currently (at least in GitHub Web UI) these take into a file not found error by pointing at the upper directory.  Thank you!