### PR TITLE
Update validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: glTF Validation
 
-on: [push, pull_request]
+on: [pull_request]
 
 env:
   CI: true
-  LINK: "https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.8/gltf_validator-2.0.0-dev.3.8-linux64.tar.xz"
+  LINK: "https://github.com/KhronosGroup/glTF-Validator/releases/download/2.0.0-dev.3.10/gltf_validator-2.0.0-dev.3.10-linux64.tar.xz"
 
 jobs:
   build:


### PR DESCRIPTION
Running the validator only on `pull_request` events ensures that it runs only on the merged tree. So all currently open PRs won't need to be resynced with `main` to use the new validator version.