### PR TITLE
README badge update, part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # glTF V2.0 Sample Assets
 
-[![glTF Validation](https://github.com/KhronosGroup/glTF-Sample-Assets/workflows/glTF%20Validation/badge.svg?branch=main)](https://github.com/KhronosGroup/glTF-Sample-Assets/actions)
+[![glTF Validation](https://github.com/KhronosGroup/glTF-Sample-Assets/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/KhronosGroup/glTF-Sample-Assets/actions/workflows/ci.yml)
 
 
 |  |  |


### PR DESCRIPTION
Second fix for #185.

Looks like the markdown needs to be updated.  I rebuilt it by [Using the UI](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge#using-the-ui).