### PR TITLE
Fix required extensions duplicated in used extensions

### DIFF
--- a/Models/AnimationPointerUVs/README.md
+++ b/Models/AnimationPointerUVs/README.md
@@ -13,8 +13,6 @@
 
 ### Used
 
-* KHR_materials_unlit
-* KHR_lights_punctual
 * KHR_materials_transmission
 * KHR_materials_volume
 * KHR_materials_specular

--- a/Models/ClearCoatCarPaint/README.md
+++ b/Models/ClearCoatCarPaint/README.md
@@ -15,8 +15,6 @@
 
 * KHR_texture_transform
 * KHR_materials_clearcoat
-* KHR_texture_transform
-* KHR_materials_clearcoat
 
 ## Summary
 

--- a/Models/CommercialRefrigerator/README.md
+++ b/Models/CommercialRefrigerator/README.md
@@ -12,7 +12,6 @@
 
 ### Used
 
-* KHR_materials_transmission
 * KHR_materials_clearcoat
 * KHR_materials_transmission
 

--- a/Models/DiffuseTransmissionTest/README.md
+++ b/Models/DiffuseTransmissionTest/README.md
@@ -13,8 +13,6 @@
 
 ### Used
 
-* KHR_materials_unlit
-* KHR_lights_punctual
 * KHR_materials_diffuse_transmission
 * KHR_materials_unlit
 * KHR_lights_punctual

--- a/Models/DirectionalLight/README.md
+++ b/Models/DirectionalLight/README.md
@@ -13,7 +13,6 @@
 ### Used
 
 * KHR_lights_punctual
-* KHR_lights_punctual
 
 ## Summary
 

--- a/Models/GlamVelvetSofa/README.md
+++ b/Models/GlamVelvetSofa/README.md
@@ -13,7 +13,6 @@
 ### Used
 
 * KHR_texture_transform
-* KHR_texture_transform
 * KHR_materials_sheen
 * KHR_materials_specular
 * KHR_materials_variants

--- a/Models/PotOfCoalsAnimationPointer/README.md
+++ b/Models/PotOfCoalsAnimationPointer/README.md
@@ -15,10 +15,6 @@
 
 ### Used
 
-* KHR_materials_specular
-* KHR_materials_transmission
-* KHR_materials_volume
-* KHR_texture_transform
 * KHR_animation_pointer
 * KHR_materials_clearcoat
 * KHR_materials_specular

--- a/Models/SheenChair/README.md
+++ b/Models/SheenChair/README.md
@@ -13,7 +13,6 @@
 ### Used
 
 * KHR_texture_transform
-* KHR_texture_transform
 * KHR_materials_sheen
 * KHR_materials_variants
 

--- a/Models/SheenCloth/README.md
+++ b/Models/SheenCloth/README.md
@@ -13,7 +13,6 @@
 ### Used
 
 * KHR_texture_transform
-* KHR_texture_transform
 * KHR_materials_sheen
 
 ## Summary

--- a/Models/SheenTestGrid/README.md
+++ b/Models/SheenTestGrid/README.md
@@ -13,7 +13,6 @@
 ### Used
 
 * KHR_materials_sheen
-* KHR_materials_sheen
 
 ## Summary
 

--- a/Models/SheenWoodLeatherSofa/README.md
+++ b/Models/SheenWoodLeatherSofa/README.md
@@ -13,8 +13,6 @@
 
 ### Used
 
-* KHR_texture_transform
-* EXT_texture_webp
 * KHR_materials_specular
 * KHR_materials_sheen
 * KHR_texture_transform

--- a/Models/SpecGlossVsMetalRough/README.md
+++ b/Models/SpecGlossVsMetalRough/README.md
@@ -13,7 +13,6 @@
 ### Used
 
 * KHR_materials_pbrSpecularGlossiness
-* KHR_materials_pbrSpecularGlossiness
 
 ## Summary
 

--- a/Models/SpecularSilkPouf/README.md
+++ b/Models/SpecularSilkPouf/README.md
@@ -15,8 +15,6 @@
 
 * KHR_materials_specular
 * KHR_materials_sheen
-* KHR_materials_specular
-* KHR_materials_sheen
 
 ## Summary
 

--- a/Models/TextureTransformMultiTest/README.md
+++ b/Models/TextureTransformMultiTest/README.md
@@ -12,7 +12,6 @@
 
 ### Used
 
-* KHR_texture_transform
 * KHR_materials_clearcoat
 * KHR_materials_unlit
 * KHR_texture_transform

--- a/Models/UnlitTest/README.md
+++ b/Models/UnlitTest/README.md
@@ -13,7 +13,6 @@
 ### Used
 
 * KHR_materials_unlit
-* KHR_materials_unlit
 
 ## Summary
 

--- a/util/modelmetadata.php
+++ b/util/modelmetadata.php
@@ -448,6 +448,7 @@ class ModelMetadata
 					$extList[] = "* " . $this->metadata['extensions']['Required'][$ii];
 				}
 				$readme[] = join("\n", $extList);
+				$extList = [];
 				$readme[] = "### Used";
 				for ($ii=0; $ii<count($this->metadata['extensions']['Used']); $ii++) {
 					$extList[] = "* " . $this->metadata['extensions']['Used'][$ii];


### PR DESCRIPTION
Due to a bug in the PHP script, required extensions were being duplicated under used extensions. This PR fixes it.