### PR TITLE
Fix missing summaries of Corset and StainedGlassLamp

### DIFF
--- a/Models/Corset/README.md
+++ b/Models/Corset/README.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
- 
+A female fabric mannequin with a corset and a collar.
 
 ## Operations
 

--- a/Models/Corset/metadata.json
+++ b/Models/Corset/metadata.json
@@ -20,6 +20,6 @@
     "screenshot": "screenshot/screenshot.jpg",
     "name": "Corset",
     "path": "./Models/Corset",
-    "summary": " ",
+    "summary": "A female fabric mannequin with a corset and a collar.",
     "createReadme": true
 }

--- a/Models/StainedGlassLamp/README.md
+++ b/Models/StainedGlassLamp/README.md
@@ -14,7 +14,7 @@
 
 ## Summary
 
- 
+A real product, a Tiffany-style stained glass table lamp sold on the Wayfair website.
 
 ## Operations
 

--- a/Models/StainedGlassLamp/metadata.json
+++ b/Models/StainedGlassLamp/metadata.json
@@ -20,6 +20,6 @@
     "screenshot": "screenshot/screenshot.jpg",
     "name": "Stained Glass Lamp",
     "path": "./Models/StainedGlassLamp",
-    "summary": " ",
+    "summary": "A real product, a Tiffany-style stained glass table lamp sold on the Wayfair website.",
     "createReadme": true
 }


### PR DESCRIPTION
`Corset` and `StainedGlassLamp` were both missing descriptions in the JSON metadata. This PR adds them, based on the text already present in the README.body.md files.

Without any description at all, the PHP scripts will show errors. These files previously contained a workaround where the description was `" "`, a single space character.