### PR TITLE
Update Scattering Skull asset with newest spec

### DIFF
--- a/Models/ScatteringSkull/glTF/ScatteringSkull.gltf
+++ b/Models/ScatteringSkull/glTF/ScatteringSkull.gltf
@@ -132,7 +132,7 @@
                     }
                 },
                 "KHR_materials_volume_scatter": {
-                    "multiscatterColor": [
+                    "multiscatterColorFactor": [
                         0.16827136278152467,
                         0.5271198749542236,
                         0.5906253457069397


### PR DESCRIPTION
This PR just updates the `multiscatterColor` parameter to `multiscatterColorFactor` which matches the most recent spec of `KHR_materials_volume_scatter`