### PR TITLE
Assign CI update to Github action

### DIFF
--- a/.github/workflows/RebuildAllAssets.yml
+++ b/.github/workflows/RebuildAllAssets.yml
@@ -30,9 +30,17 @@ jobs:
     - name: Commit changes to a new branch 
       uses: EndBug/add-and-commit@v9
       with:
-        # Defaults for most parameters are used
-        # Action assigned to "github_actor" (used by default with 'default_author')
         # This action merges all changes into 'main'
+
+        # Defaults for most parameters are used
+
+        # Action assigned to "Github actions"
+        default_author: github_actions
+
+        # The commit message will be
+        # "Commit from GitHub Actions (Rebuild All Model Assets)"
+        # with the last part being the name of this
+        # action, given at the top of this file.
 
         # The way the action should handle pathspec errors from the add and remove commands. Three options are available:
         # - ignore -> errors will be logged but the step won't fail


### PR DESCRIPTION
Until now, the automated commit that was triggered by CI and carried the commit message

> Commit from GitHub Actions (Rebuild All Model Assets)

was attributed to the author of the _last_ commit that happened before things had been merged into `main`. This could be confusing, because these changes had, in fact, _not_ been done by that author, but by CI.

This PR updates the `RebuildAllAssets.yml` to set
`default_author: github_actions`
so that this commit is attributed to GitHub actions.

An example/test for what this will look like is shown in https://github.com/javagl/glTF-Sample-Assets/pull/6

@lexaknyazev You can merge this at any time, otherwise, I'd merge it a bit later.


