### PR TITLE
Update links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 |  |  |
 |-|-|
-| [![Glass Hurricane Candle Holder](Models/GlassHurricaneCandleHolder/screenshot/screenshot.jpg)](Models/GlassHurricaneCandleHolder/README.md)  | Glass candle holder using Transmission and Volume extensions. [[Show]](https://github.khronos.org/glTF-Sample-Viewer-Release/?model=https://raw.GithubUserContent.com/DRx3D/glTF-Sample-Models/main/Models/GlassHurricaneCandleHolder/glTF-Binary/GlassHurricaneCandleHolder.glb)<br>Credit:<br>&copy; 2021, Wayfair, LLC. [CC BY 4.0 International](https://creativecommons.org/licenses/by/4.0/legalcode)<br> - Eric Chadwick for everything
+| [![Glass Hurricane Candle Holder](Models/GlassHurricaneCandleHolder/screenshot/screenshot.jpg)](Models/GlassHurricaneCandleHolder/README.md)  | Glass candle holder using Transmission and Volume extensions. [[Show]](https://github.khronos.org/glTF-Sample-Viewer-Release/?model=https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/GlassHurricaneCandleHolder/glTF-Binary/GlassHurricaneCandleHolder.glb)<br>Credit:<br>&copy; 2021, Wayfair, LLC. [CC BY 4.0 International](https://creativecommons.org/licenses/by/4.0/legalcode)<br> - Eric Chadwick for everything
 
 
 ## Introduction
@@ -50,7 +50,6 @@ Sample models help the glTF ecosystem, if you are able to contribute a model, se
 ## Model Publishing Services with glTF Download Capability
 
 * [Sketchfab](https://sketchfab.com/features/gltf) offers auto-conversion of all of its downloadable models, including PBR models, to glTF format.
-* [Poimandres Market](https://market.pmnd.rs/) offers 3D assets for download in glTF format.
 * [Poly Haven](https://polyhaven.com/) offers CC0 (public domain equivalent) HDRIs, PBR textures, and glTF models.
 
 ## Other glTF Models
@@ -58,11 +57,11 @@ Sample models help the glTF ecosystem, if you are able to contribute a model, se
 For additional glTF models, see:
 
 * [Khronos glTF Asset Generator](https://github.com/KhronosGroup/glTF-Asset-Generator) offers an extensive suite of test models to exercise each part of the glTF specification.
-* Cesium's [demo models](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Apps/SampleData/models) and [unit test models](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Specs/Data/Models).
+* Cesium's [demo models](https://github.com/CesiumGS/cesium/tree/master/Apps/SampleData/models) and [unit test models](https://github.com/CesiumGS/cesium/tree/master/Specs/Data/Models).
 * Flightradar24's [GitHub repo](https://github.com/kalmykov/fr24-3d-models) of aircrafts.
 * [Kenney • Assets](https://kenney.nl/assets?q=3d) hundreds of themed low-poly assets (nature, space, castle, furniture, etc.) provided by Kenney under CC0 licenses, including [30+ pirate themed models](https://kenney.nl/assets/pirate-kit).
 * [Sketchfab](https://sketchfab.com/3d-models?features=downloadable&sort_by=-likeCount) for thousands of Creative Commons models.
-* [Smithsonian open access 3D models](https://3d.si.edu/cc0?edan_q=*:*&edan_fq[]=online_media_type:%223D+Images%22)
+* [Smithsonian open access 3D models](https://3d.si.edu/)
 
 ## Questions or Comments
 


### PR DESCRIPTION
- The GlassHurricaneCandleHolder demo GLB was taken from a fork
- The "Poimandres Market" website is a 404
- The Cesium links no longer use "AnalyticalGraphicsInc"
- The Smithonian link contained an invalid query