### PR TITLE
Fill out license fields for known licenses

### DIFF
--- a/util/src/Models.ts
+++ b/util/src/Models.ts
@@ -231,8 +231,15 @@ export class Models {
   }
 
   /**
-   * Validate the given legal object, checking for the consistency
-   * of custom licenses and their required license file
+   * Validate the given legal object.
+   *
+   * For known licenses (i.e. SPDX licenses that are listed in the
+   * data/licenses.json), this will fill out the 'spdx', 'licenseUrl',
+   * 'text' and 'icon' fields of the given object based on the
+   * canonical information from the 'licenses.json' file.
+   *
+   * For custom licenses, this will check for the consistency of the
+   * license name and the required license file.
    *
    * @param modelPath - The path that contains the model, e.g.
    * "./Models/AnimatedTriangle".
@@ -244,12 +251,21 @@ export class Models {
     const knownLicenses = Licenses.LICENSE;
     const license = legal.license;
     const knownLicense = knownLicenses[license];
-    if (knownLicense === undefined) {
+
+    if (knownLicense) {
+      // For known (SPDX) licenses, fill out the canonical fields
+      legal.spdx = license;
+      legal.icon = knownLicense.icon;
+      legal.text = knownLicense.text;
+      legal.licenseUrl = knownLicense.link;
+    } else {
+      // For custom license files, check for the presence of the 'text'
+      // (which is used as the link text)
       if (legal.text === undefined) {
         errors.push(`License ${license} is not known - the 'text' is required`);
       }
 
-      // Check for the presence of the license file
+      // Check for the presence of the custom license file
       const expectedLicenseFile = `./LICENSES/${license}.txt`;
       if (!fs.existsSync(expectedLicenseFile)) {
         errors.push(


### PR DESCRIPTION
Fixes an issue with the license handling that was introduced in https://github.com/KhronosGroup/glTF-Sample-Assets/pull/280 :  

The requirement for the license (`legal`) entries in the metadata JSON are now that they must contain
`license`
`year`
`artist`
`what`
`owner`
where `license` is usually one of the _known_ SPDX identifiers. 

The intention here was to fill out the remaining fields of the license data (specifically, `spdx`, `text`, `licenseUrl`, and `icon`) with the canonical values that are found in the [`licenses.json`](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/main/util/data/licenses.json) for that SPDX identifier.

The current state did **not** "auto-complete" these properties, meaning that when they had been missing in the input, it would lead to invalid output - for example, see [the `undefined` in this generated file](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/0659df50d4711ef687d2fb23736032f61bcfce82/Models/NodeVisibilityTest/LICENSE.md). After this pull request is merged, the (potentially) missing fields should be updated accordingly, meaning that the respective line in that output will become 

>  * [Creative Commons Zero v1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/legalcode) [SPDX license identifier: "CC0-1.0"]

