### PR TITLE
Use consistent license text properties

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ The following licenses are currently supported. Their 'SPDX identifier' can be u
 | CC0-1.0 | Creative Commons Zero v1.0 Universal | https://creativecommons.org/publicdomain/zero/1.0/legalcode |
 | CC-BY-4.0 | Creative Commons Attribution 4.0 International | https://creativecommons.org/licenses/by/4.0/legalcode |
 | CC-BY-NC-4.0 | Creative Commons Attribution Non Commercial 4.0 International | https://creativecommons.org/licenses/by-nc/4.0/legalcode |
-| CC-BY-NC-SA-4.0 | Creative Commons, Attribution-NonCommercial-ShareAlike 4.0 International | https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode |
+| CC-BY-NC-SA-4.0 | Creative Commons Attribution Non Commercial Share Alike 4.0 International | https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode |
 
 
 ## Appendix B: AI-Assisted Contributions

--- a/util/data/licenses.json
+++ b/util/data/licenses.json
@@ -20,7 +20,7 @@
   "CC-BY-NC-SA-4.0": {
     "icon": "https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png",
     "link": "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode",
-    "text": "Creative Commons, Attribution-NonCommercial-ShareAlike 4.0 International",
+    "text": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
     "spdx": "CC-BY-NC-SA-4.0"
   }
 }


### PR DESCRIPTION
This was noticed during the call today: The contributing guide (and the JSON file that lists the available licenses) used inconsistent names ("text") for the license. Specifically, the `CC-BY-NC-SA-4.0` text was
`Creative Commons, Attribution-NonCommercial-ShareAlike 4.0 International`

I now took the "Full name" from https://spdx.org/licenses/, which says
`Creative Commons Attribution Non Commercial Share Alike 4.0 International`

That's consistent with the other ones. 

Beyond that, one could argue what the "right" text is. I almost certainly took the "wrong" name from the official link at https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode, which says
`Attribution-NonCommercial-ShareAlike 4.0 International`
in the title. No strong preference from my side.



